### PR TITLE
Update to play-json 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Here are the versions of this plugin compatible with the Play JSON library
 
 | Plugin version | Play version    |
 |----------------|-----------------|
+| 2.5.0          |  2.5.x          |
 | 2.4.0          |  2.4.x          |
 | 2.3.0          | [2.2.x, 2.3.x]  |
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
 libraryDependencies ++= Seq(
-	"com.typesafe.play" %% "play-json" % "[2.4.0,2.4.+)",
+	"com.typesafe.play" %% "play-json" % "[2.5.0,2.5.+)",
 	"io.gatling" %% "jsonpath" % "0.6.4",
   "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "play-jsonpath"
 
 organization := "com.josephpconley"
 
-version := "2.4.0"
+version := "2.5.0"
 
 scalaVersion := "2.11.4"
 


### PR DESCRIPTION
Update library to use play-json 2.5.  Using the play-json 2.4 version of this library with play-json 2.5 results in a NoSuchMethodError.

Thank you for creating this helpful library.